### PR TITLE
feat: implement direct file upload for profile pictures

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@reduxjs/toolkit": "^2.9.0",
-    "@studious-lms/server": "^1.1.3",
+    "@studious-lms/server": "^1.1.4",
     "@tanstack/react-query": "^5.87.1",
     "@tanstack/react-table": "^8.21.3",
     "@trpc/react-query": "^11.5.1",

--- a/src/components/AvatarSelector.tsx
+++ b/src/components/AvatarSelector.tsx
@@ -28,7 +28,7 @@ import { cn } from "@/lib/utils";
 
 interface AvatarSelectorProps {
   currentAvatar?: string;
-  onAvatarSelect: (avatarUrl: string, isCustom: boolean) => void;
+  onAvatarSelect: (avatarUrl: string, isCustom: boolean, fileName?: string, fileType?: string, file?: File) => void;
   disabled?: boolean;
   size?: "sm" | "md" | "lg";
 }
@@ -70,6 +70,7 @@ export function AvatarSelector({
   const [selectedSeed, setSelectedSeed] = useState(generateRandomSeed());
   const [isUploading, setIsUploading] = useState(false);
   const [previewImage, setPreviewImage] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const sizeClasses = {
@@ -101,10 +102,20 @@ export function AvatarSelector({
     const file = event.target.files?.[0];
     if (!file) return;
 
+    // Validate file type
+    const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
+    if (!allowedTypes.includes(file.type)) {
+      alert("Please upload a valid image file (JPEG, PNG, GIF, or WebP)");
+      return;
+    }
+
     if (file.size > 5 * 1024 * 1024) {
       alert("Profile picture must be less than 5MB");
       return;
     }
+
+    // Store the file for later use
+    setSelectedFile(file);
 
     // Show preview first
     const reader = new FileReader();
@@ -116,11 +127,11 @@ export function AvatarSelector({
   };
 
   const handleConfirmUpload = async () => {
-    if (!previewImage) return;
+    if (!previewImage || !selectedFile) return;
 
     setIsUploading(true);
     try {
-      onAvatarSelect(previewImage, true);
+      onAvatarSelect(previewImage, true, selectedFile.name, selectedFile.type, selectedFile);
       setIsOpen(false);
     } catch (error) {
       console.error("Failed to upload image:", error);
@@ -137,6 +148,7 @@ export function AvatarSelector({
   React.useEffect(() => {
     if (isOpen) {
       setPreviewImage(null);
+      setSelectedFile(null);
     }
   }, [isOpen]);
 
@@ -289,7 +301,7 @@ export function AvatarSelector({
                   <input
                     ref={fileInputRef}
                     type="file"
-                    accept="image/*"
+                    accept="image/jpeg,image/jpg,image/png,image/gif,image/webp"
                     onChange={handleCustomUpload}
                     className="hidden"
                   />
@@ -311,7 +323,10 @@ export function AvatarSelector({
                   <div className="flex justify-center space-x-2">
                     <Button 
                       variant="outline" 
-                      onClick={() => setPreviewImage(null)}
+                      onClick={() => {
+                        setPreviewImage(null);
+                        setSelectedFile(null);
+                      }}
                       className="flex items-center space-x-2"
                     >
                       <X className="h-4 w-4" />

--- a/src/lib/trpc.ts
+++ b/src/lib/trpc.ts
@@ -16,6 +16,8 @@ export type AuthCheckOutput = RouterOutputs['auth']['check'];
 // ===== USER TYPES =====
 export type UserGetProfileOutput = RouterOutputs['user']['getProfile'];
 export type UserUpdateProfileInput = RouterInputs['user']['updateProfile'];
+export type UserGetUploadUrlInput = RouterInputs['user']['getUploadUrl'];
+export type UserGetUploadUrlOutput = RouterOutputs['user']['getUploadUrl'];
 
 // ===== CLASS TYPES =====
 export type ClassGetAllOutput = RouterOutputs['class']['getAll'];


### PR DESCRIPTION
- Replace base64 with direct GCS upload using signed URLs
- Add getUploadUrl mutation and filePath-based profile updates
- Separate custom uploads from DiceBear avatar handling
- Add upload error handling and visual feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload a custom profile picture (JPEG, JPG, PNG, GIF, WEBP; up to 5MB) with live preview before saving.
  * Choose a generated DiceBear-style avatar as an alternative to uploads.
  * Direct upload flow using pre-signed URLs so files are uploaded before profile save.

* **UX Improvements**
  * Avatar area shows live preview and a clear “pending change” indicator.
  * Prompts to Save Changes after selecting a new image or avatar.
  * Improved validation with alerts for unsupported types or oversized files; cancel/clear resets pending selections.

* **Chores**
  * Dependency update to a server package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->