### PR TITLE
fix(profile): invalidate profile query cache after successful update

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -61,6 +61,7 @@ export default function Profile() {
   const { data: profile, isLoading, error } = trpc.user.getProfile.useQuery();
   const updateProfileMutation = trpc.user.updateProfile.useMutation();
   const getUploadUrlMutation = trpc.user.getUploadUrl.useMutation();
+  const utils = trpc.useUtils();
 
   // Form setup
   const form = useForm<ProfileFormValues>({
@@ -133,6 +134,10 @@ export default function Profile() {
       }
 
       await updateProfileMutation.mutateAsync(updateData);
+      
+      // Invalidate and refetch the profile query to update the UI immediately
+      await utils.user.getProfile.invalidate();
+      
       toast.success("Profile updated successfully");
       setIsEditing(false);
       setPendingProfilePicture(null);

--- a/src/components/AvatarSelector.tsx
+++ b/src/components/AvatarSelector.tsx
@@ -100,18 +100,21 @@ export function AvatarSelector({
   };
 
   const handleCustomUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
+    const input = event.currentTarget;
+    const file = input.files?.[0];
     if (!file) return;
 
     // Validate file type
     const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
     if (!allowedTypes.includes(file.type)) {
       toast.error("Please upload a valid image (JPEG, PNG, GIF, or WebP)");
+      input.value = "";
       return;
     }
 
     if (file.size > 5 * 1024 * 1024) {
       toast.error("Profile picture must be less than 5MB");
+      input.value = "";
       return;
     }
 
@@ -136,6 +139,7 @@ export function AvatarSelector({
       setIsOpen(false);
     } catch (error) {
       console.error("Failed to upload image:", error);
+      toast.error("Failed to process the image. Please try again.");
     } finally {
       setIsProcessing(false);
     }
@@ -328,15 +332,17 @@ export function AvatarSelector({
                       onClick={() => {
                         setPreviewImage(null);
                         setSelectedFile(null);
+                        if (fileInputRef.current) fileInputRef.current.value = "";
                       }}
                       className="flex items-center space-x-2"
                     >
                       <X className="h-4 w-4" />
                       <span>Choose Different</span>
                     </Button>
-                    <Button 
+                    <Button
                       onClick={handleConfirmUpload}
                       disabled={isProcessing}
+                      aria-busy={isProcessing}
                       className="flex items-center space-x-2"
                     >
                       {isProcessing ? (

--- a/src/components/AvatarSelector.tsx
+++ b/src/components/AvatarSelector.tsx
@@ -25,6 +25,7 @@ import {
   X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { toast } from "sonner";
 
 interface AvatarSelectorProps {
   currentAvatar?: string;
@@ -68,7 +69,7 @@ export function AvatarSelector({
   const [isOpen, setIsOpen] = useState(false);
   const [selectedStyle, setSelectedStyle] = useState("avataaars");
   const [selectedSeed, setSelectedSeed] = useState(generateRandomSeed());
-  const [isUploading, setIsUploading] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
   const [previewImage, setPreviewImage] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -105,12 +106,12 @@ export function AvatarSelector({
     // Validate file type
     const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
     if (!allowedTypes.includes(file.type)) {
-      alert("Please upload a valid image file (JPEG, PNG, GIF, or WebP)");
+      toast.error("Please upload a valid image (JPEG, PNG, GIF, or WebP)");
       return;
     }
 
     if (file.size > 5 * 1024 * 1024) {
-      alert("Profile picture must be less than 5MB");
+      toast.error("Profile picture must be less than 5MB");
       return;
     }
 
@@ -129,14 +130,14 @@ export function AvatarSelector({
   const handleConfirmUpload = async () => {
     if (!previewImage || !selectedFile) return;
 
-    setIsUploading(true);
+    setIsProcessing(true);
     try {
       onAvatarSelect(previewImage, true, selectedFile.name, selectedFile.type, selectedFile);
       setIsOpen(false);
     } catch (error) {
       console.error("Failed to upload image:", error);
     } finally {
-      setIsUploading(false);
+      setIsProcessing(false);
     }
   };
 
@@ -164,6 +165,7 @@ export function AvatarSelector({
             disabled && "opacity-50 cursor-not-allowed"
           )}
           disabled={disabled}
+          aria-label="Change profile picture"
         >
           <Avatar className={cn("h-full w-full", sizeClasses[size])}>
             <AvatarImage src={currentAvatar} alt="Profile" />
@@ -292,7 +294,7 @@ export function AvatarSelector({
                   </div>
                   <h4 className="text-sm font-medium mb-2">Upload Custom Picture</h4>
                   <p className="text-xs text-muted-foreground mb-4">
-                    Upload a JPG, PNG, or GIF file. Maximum size 5MB.
+                    Upload a JPG, PNG, GIF, or WebP file. Maximum size 5MB.
                   </p>
                   <p className="text-xs text-muted-foreground">
                     Click here to choose a file
@@ -334,13 +336,13 @@ export function AvatarSelector({
                     </Button>
                     <Button 
                       onClick={handleConfirmUpload}
-                      disabled={isUploading}
+                      disabled={isProcessing}
                       className="flex items-center space-x-2"
                     >
-                      {isUploading ? (
+                      {isProcessing ? (
                         <>
                           <RefreshCw className="h-4 w-4 animate-spin" />
-                          <span>Uploading...</span>
+                          <span>Processing...</span>
                         </>
                       ) : (
                         <>


### PR DESCRIPTION
- Add tRPC utils to invalidate user.getProfile query after profile update
- Profile icon now updates immediately without requiring page refresh
- Improves user experience by providing real-time UI updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview and upload flow for custom profile pictures with a 15s upload timeout/abort, Enter-key form submit, and immediate profile refresh after save.
* **Bug Fixes**
  * Cancel restores current profile values; avatar and edits reflect immediately after saving.
* **UI**
  * “Uploading…” → “Processing…”, improved processing indicator, Save disabled while uploads/mutations are pending, WebP added to allowed formats.
* **Accessibility**
  * Change-picture control includes an aria-label.
* **Errors**
  * Invalid/oversized image and upload failures use toast notifications; file input clears after errors or cancel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->